### PR TITLE
Handle alternate CSV headers for events

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
 
     // Expected CSV headers (row 1):
     // Event Date, Start Time, End Time, Title, Location, Category, Canceled
+    // Also accepts: Date, Start, End (for compatibility with existing sheets)
 
     function setStatus(text, kind = "") {
       const el = document.getElementById("status");
@@ -148,11 +149,11 @@
     }
 
     function toFullCalendarEvent(row) {
-      const eventDate = parseMMDDYYYY(row["Event Date"]);
+      const eventDate = parseMMDDYYYY(row["Event Date"] ?? row["Date"]);
       if (!eventDate) return null;
 
-      const startTime = parseHHMM24(row["Start Time"]);
-      const endTime = parseHHMM24(row["End Time"]);
+      const startTime = parseHHMM24(row["Start Time"] ?? row["Start"]);
+      const endTime = parseHHMM24(row["End Time"] ?? row["End"]);
 
       const title = String(row["Title"] ?? "").trim() || "Event";
       const location = String(row["Location"] ?? "").trim();


### PR DESCRIPTION
### Motivation
- The CSV parser expected headers `Event Date`, `Start Time`, and `End Time`, but some published sheets use `Date`, `Start`, and `End`, causing `toFullCalendarEvent` to return `null` for every row and trigger the "No events found" error.

### Description
- Add fallback header support in `toFullCalendarEvent` so the code reads `row["Event Date"] ?? row["Date"]`, `row["Start Time"] ?? row["Start"]`, and `row["End Time"] ?? row["End"]`, and document the alternate headers in the header comment.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69791a24ef34833196322cee1cedb78c)